### PR TITLE
Multiple-input `hcat` method for combinations of `Vector`/`Dataset`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "StateSpaceSets"
 uuid = "40b095a5-5852-4c12-98c7-d43bf788e795"
 authors = ["George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaDynamics/StateSpaceSets.jl.git"
-version = "0.2.0"
+version = "0.1.4"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "StateSpaceSets"
 uuid = "40b095a5-5852-4c12-98c7-d43bf788e795"
 authors = ["George Datseris <datseris.george@gmail.com>"]
-version = "0.1.3"
 repo = "https://github.com/JuliaDynamics/StateSpaceSets.jl.git"
+version = "0.1.4"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "StateSpaceSets"
 uuid = "40b095a5-5852-4c12-98c7-d43bf788e795"
 authors = ["George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaDynamics/StateSpaceSets.jl.git"
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -38,6 +38,9 @@ println("\nTesting Dataset...")
         @test hcat(y, D1) |> size == (5, 3)
         @test hcat(D1, y) == Dataset(([1:5 2:6 y]))
         @test hcat(y, D1) == Dataset(([y 1:5 2:6]))
+
+        x, y, z, w = rand(100), rand(100), Dataset(rand(100, 2)), Dataset(rand(Int, 100, 3))
+        @test Dataset(x, y, z, w) == Dataset(Dataset(x), Dataset(y), z, w)
     end
 
     # TODO: By construction, these errors will occur, because the type constraints are


### PR DESCRIPTION
This PR allows creating new datasets by horizontally concatenating multiple vectors and datasets, e.g. `Dataset(rand(100), rand(100), Dataset(rand(200, 3))`. The previous three-or-more-arguments variants only accepted either `Vector` or `Dataset`, both not a mixture of both.

This operation is common in CausalityTools when doing conditional tests, where the conditioning set is a `Dataset`, while the original time series are regular `Vector`s. The methods in this PR could exist as utility methods in CausalityTools, but I think this should be available here.