### PR TITLE
Tests of state space sampler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/Users/martinmikkelsen/Documents/StateSpaceSets.jl"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/Users/martinmikkelsen/Documents/StateSpaceSets.jl"
-}

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -55,7 +55,7 @@ end
 
 function boxregion_multgauss(as, bs, rng)
     @assert length(as) == length(bs) > 0
-    center = mean(hcat(as,bs), dims=2)
+    center = mean(hcat(as,bs))
     gen() = [rand(rng, truncated(Normal(center[i]), as[i], bs[i])) for i=1:length(as)]
     isinside(x) = all(as .< x .< bs)
     return gen, isinside

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,5 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     testfile("dataset_tests.jl")
     testfile("dataset_distance_tests.jl")
     testfile("utils_tests.jl")
+    testfile("sampler_tests.jl")
 end

--- a/test/sampler_tests.jl
+++ b/test/sampler_tests.jl
@@ -1,0 +1,69 @@
+using LinearAlgebra, Random, Statistics, Test
+
+println("\nTesting sampler...")
+
+@testset "statespace_sampler" begin
+
+# Test statespace_sampler with rectangular box method
+function test_statespace_sampler_rectangular_box()
+    rng = MersenneTwister(1234)  # Seed random number generator for reproducibility
+
+    # Define rectangular box region
+    min_bounds = [-1, -2]
+    max_bounds = [1, 2]
+    method = "uniform"
+
+    # Generate sampler and isinside functions
+    gen, isinside = statespace_sampler(rng; min_bounds=min_bounds, max_bounds=max_bounds, method=method)
+
+    # Test generated points are inside the box region
+    for i in 1:250
+        x = gen()
+        @test isinside(x)
+    end
+end
+
+# Test statespace_sampler with multivariate Gaussian box method
+function test_statespace_sampler_multivariate_gaussian_box()
+    rng = MersenneTwister(1234)  # Seed random number generator for reproducibility
+
+    # Define rectangular box region
+    min_bounds = [-1, -2]
+    max_bounds = [1, 2]
+    method = "multgauss"
+
+    # Generate sampler and isinside functions
+    gen, isinside = statespace_sampler(rng; min_bounds=min_bounds, max_bounds=max_bounds, method=method)
+
+    # Test generated points are inside the box region
+    for i in 1:250
+        x = gen()
+        @test isinside(x)
+    end
+end
+
+# Test statespace_sampler with sphere method
+function test_statespace_sampler_sphere()
+    rng = MersenneTwister(1234)  # Seed random number generator for reproducibility
+
+    # Define sphere region
+    radius = 2
+    spheredims = 3
+    center = [1, 2, 3]
+
+    # Generate sampler and isinside functions
+    gen, isinside = statespace_sampler(rng; radius=radius, spheredims=spheredims, center=center)
+
+    # Test generated points are inside the sphere region
+    for i in 1:250
+        x = gen()
+        @test isinside(x)
+    end
+end
+
+
+# Run tests
+    test_statespace_sampler_rectangular_box()
+    test_statespace_sampler_multivariate_gaussian_box()
+    test_statespace_sampler_sphere()
+end

--- a/test/sampler_tests.jl
+++ b/test/sampler_tests.jl
@@ -19,6 +19,7 @@ function test_statespace_sampler_rectangular_box()
     # Test generated points are inside the box region
     for i in 1:250
         x = gen()
+        @test all(min_bounds .<= x .<= max_bounds)
         @test isinside(x)
     end
 end
@@ -38,6 +39,7 @@ function test_statespace_sampler_multivariate_gaussian_box()
     # Test generated points are inside the box region
     for i in 1:250
         x = gen()
+        @test all(min_bounds .<= x .<= max_bounds)
         @test isinside(x)
     end
 end
@@ -57,6 +59,7 @@ function test_statespace_sampler_sphere_3D()
     # Test generated points are inside the sphere region
     for i in 1:250
         x = gen()
+        @test norm(x - center) <= radius
         @test isinside(x)
     end
 end
@@ -76,6 +79,7 @@ function test_statespace_sampler_sphere_4D()
     # Test generated points are inside the sphere region
     for i in 1:250
         x = gen()
+        @test norm(x - center) <= radius
         @test isinside(x)
     end
 end
@@ -86,5 +90,4 @@ end
     test_statespace_sampler_multivariate_gaussian_box()
     test_statespace_sampler_sphere_3D()
     test_statespace_sampler_sphere_4D()
-
 end

--- a/test/sampler_tests.jl
+++ b/test/sampler_tests.jl
@@ -43,7 +43,7 @@ function test_statespace_sampler_multivariate_gaussian_box()
 end
 
 # Test statespace_sampler with sphere method
-function test_statespace_sampler_sphere()
+function test_statespace_sampler_sphere_3D()
     rng = MersenneTwister(1234)  # Seed random number generator for reproducibility
 
     # Define sphere region
@@ -61,9 +61,30 @@ function test_statespace_sampler_sphere()
     end
 end
 
+# Test statespace_sampler with sphere method
+function test_statespace_sampler_sphere_4D()
+    rng = MersenneTwister(1234)  # Seed random number generator for reproducibility
+
+    # Define sphere region
+    radius = 2
+    spheredims = 4
+    center = [1, 2, 3, 7]
+
+    # Generate sampler and isinside functions
+    gen, isinside = statespace_sampler(rng; radius=radius, spheredims=spheredims, center=center)
+
+    # Test generated points are inside the sphere region
+    for i in 1:250
+        x = gen()
+        @test isinside(x)
+    end
+end
+
 
 # Run tests
     test_statespace_sampler_rectangular_box()
     test_statespace_sampler_multivariate_gaussian_box()
-    test_statespace_sampler_sphere()
+    test_statespace_sampler_sphere_3D()
+    test_statespace_sampler_sphere_4D()
+
 end


### PR DESCRIPTION
This PR includes a quick implementation of tests of the state space sampler. I've organized it in the following way:
The tests are organized within a ``@testset`` block named ``statespace_sampler``. Within this block are the test functions, for instance:

``test_statespace_sampler_rectangular_box()``: This function tests the ``statespace_sampler`` function with a rectangular box method. It defines a rectangular box region with minimum and maximum bounds, generates a sampler and an isinside function using ``statespace_sampler`` with the specified parameters, and then generates random points using the ``gen()`` function and checks if they are inside the box region using the ``isinside()`` function. This test is repeated 250 times using a for loop.

And similarly for ``test_statespace_sampler_multivariate_gaussian_box()``, ``test_statespace_sampler_sphere_3D()``, and ``test_statespace_sampler_sphere_4D()``.

I noticed the tests for ``sampler_multivariate_gaussian_box()`` failed with error: 
``Got exception outside of a @test
  MethodError: no method matching mean(::StateSpaceSet{2, Int64}; dims=2)``. 

For some reason, it passes when I delete ``dims=2``  in ``center = mean(hcat(as,bs), dims=2)``?
