### PR TITLE
Allow empty containers in `setsofsets_distances`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog for StateSpaceSets.jl is kept w.r.t. version 1.3
 
+# 2.4
+
+- Containers in `setsofsets_distances` can now be both empty. They must be concretely typed.
+- Fixed some inconsistency in `eltype(ssset)`. Now it always returns the type of the contained points. Before it was ambiguously defined and could return the number type.
+
 # 2.3
 
 - `set_distance` now also allows any arbitrary function `f`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog for StateSpaceSets.jl is kept w.r.t. version 1.3
 # 2.4
 
 - Containers in `setsofsets_distances` can now be both empty. They must be concretely typed.
-- Fixed some inconsistency in `eltype(ssset)`. Now it always returns the type of the contained points. Before it was ambiguously defined and could return the number type.
+- Fixed a critical bug where `eltype(ssset)` would return the element type of the stored points (e.g., `Float64`), instead of the type of the points themselves (e.g., `SVector{2, Float64}`). To be consistent with the Array interface and base Julia the correct return value is the type of the points themselves. Use `eltype(eltype(ssset))` to obtain the number type of the points.
 
 # 2.3
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "StateSpaceSets"
 uuid = "40b095a5-5852-4c12-98c7-d43bf788e795"
 authors = ["George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaDynamics/StateSpaceSets.jl.git"
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/set_distance.jl
+++ b/src/set_distance.jl
@@ -152,12 +152,13 @@ the `i` key of `a₊` to the `j` key of `a₋`. Distances from `a₋` to
 `a₊` are not computed at all, assumming symmetry in the distance function.
 
 The `distance` can be anything valid for [`set_distance`](@ref).
+
+Containers `a₊, a₋` can be empty but they must be concretely typed.
 """
 function setsofsets_distances(a₊, a₋, method = Centroid())
-    (isempty(a₊) || isempty(a₋)) && error("The set containers must be non-empty.")
     ids₊, ids₋ = keys(a₊), keys(a₋)
-    gettype = a -> eltype(first(values(a)))
-    T = promote_type(gettype(a₊), gettype(a₋))
+    numbertype = a -> eltype(eltype(valtype(a)))
+    T = promote_type(numbertype(a₊), numbertype(a₋))
     distances = Dict{eltype(ids₊), Dict{eltype(ids₋), T}}()
     _setsofsets_distances!(distances, a₊, a₋, method)
 end
@@ -175,7 +176,6 @@ function _setsofsets_distances!(distances, a₊, a₋, c::Centroid)
 end
 
 function _setsofsets_distances!(distances, a₊, a₋, method::Hausdorff)
-    @assert keytype(a₊) == keytype(a₋)
     metric = method.metric
     trees₊ = Dict(m => KDTree(vec(att), metric) for (m, att) in pairs(a₊))
     trees₋ = Dict(m => KDTree(vec(att), metric) for (m, att) in pairs(a₋))

--- a/src/set_distance.jl
+++ b/src/set_distance.jl
@@ -157,7 +157,7 @@ Containers `a₊, a₋` can be empty but they must be concretely typed.
 """
 function setsofsets_distances(a₊, a₋, method = Centroid())
     ids₊, ids₋ = keys(a₊), keys(a₋)
-    numbertype = a -> eltype(eltype(valtype(a)))
+    numbertype = a -> eltype(eltype(valtype(a))) # numeric type = type of distance
     T = promote_type(numbertype(a₊), numbertype(a₋))
     distances = Dict{eltype(ids₊), Dict{eltype(ids₋), T}}()
     _setsofsets_distances!(distances, a₊, a₋, method)

--- a/src/set_distance.jl
+++ b/src/set_distance.jl
@@ -113,9 +113,9 @@ end
 # The comparison version exists because when passing `>` it is used in `Hausdorf`
 function set_distance_tree(d1, tree::KDTree, comparison = <)
     if comparison === <
-        ε = eltype(d1)(Inf)
+        ε = eltype(eltype(d1))(Inf)
     elseif comparison === >
-        ε = eltype(d1)(-Inf)
+        ε = eltype(eltype(d1))(-Inf)
     end
     # We use internal source code extracted from NearestNeighbors.jl for max performance
     dist, idx = [ε], [0]
@@ -129,7 +129,7 @@ function set_distance_tree(d1, tree::KDTree, comparison = <)
 end
 
 function set_distance_brute(d1, d2::AbstractStateSpaceSet, metric = Euclidean())
-    ε = eltype(d2)(Inf)
+    ε = eltype(eltype(d2))(Inf)
     for x ∈ d1
         for y ∈ d2
             εnew = metric(x, y)

--- a/src/statespaceset.jl
+++ b/src/statespaceset.jl
@@ -35,7 +35,6 @@ Base.:(==)(d1::AbstractStateSpaceSet, d2::AbstractStateSpaceSet) = vec(d1) == ve
 Base.copy(d::AbstractStateSpaceSet) = typeof(d)(copy(vec(d)))
 Base.sort(d::AbstractStateSpaceSet) = sort!(copy(d))
 @inline Base.eltype(::Type{<:AbstractStateSpaceSet{D, T, V}}) where {D, T, V} = V
-@inline Base.eltype(::AbstractStateSpaceSet{D, T, V}) where {D, T, V} = V
 @inline Base.IteratorSize(::Type{<:AbstractStateSpaceSet}) = Base.HasLength()
 Base.eachcol(ds::AbstractStateSpaceSet) = (ds[:, i] for i in 1:dimension(ds))
 

--- a/src/statespaceset.jl
+++ b/src/statespaceset.jl
@@ -19,7 +19,6 @@ abstract type AbstractStateSpaceSet{D, T, V} <: AbstractVector{V} end
 Return the dimension of the `thing`, in the sense of state-space dimensionality.
 """
 dimension(::AbstractStateSpaceSet{D}) where {D} = D
-Base.eltype(::AbstractStateSpaceSet{D,T}) where {D,T} = T
 Base.vec(X::AbstractStateSpaceSet) = X.data
 containertype(::AbstractStateSpaceSet{D,T,V}) where {D,T,V} = V
 
@@ -35,7 +34,8 @@ end
 Base.:(==)(d1::AbstractStateSpaceSet, d2::AbstractStateSpaceSet) = vec(d1) == vec(d2)
 Base.copy(d::AbstractStateSpaceSet) = typeof(d)(copy(vec(d)))
 Base.sort(d::AbstractStateSpaceSet) = sort!(copy(d))
-@inline Base.eltype(::Type{<:AbstractStateSpaceSet{D, T}}) where {D, T} = SVector{D, T}
+@inline Base.eltype(::Type{<:AbstractStateSpaceSet{D, T, V}}) where {D, T, V} = V
+@inline Base.eltype(::AbstractStateSpaceSet{D, T, V}) where {D, T, V} = V
 @inline Base.IteratorSize(::Type{<:AbstractStateSpaceSet}) = Base.HasLength()
 Base.eachcol(ds::AbstractStateSpaceSet) = (ds[:, i] for i in 1:dimension(ds))
 

--- a/src/statespaceset.jl
+++ b/src/statespaceset.jl
@@ -101,7 +101,7 @@ function _hcat(xs::Union{AbstractVector{<:Real}, AbstractStateSpaceSet}...)
     all(Ls .== maxlen) || error("StateSpaceSets must be of same length")
     V = findcontainertype(xs...)
     newdim = sum(dimension.(ds))
-    T = promote_type(eltype.(ds)...)
+    T = promote_type(eltype.(eltype.(ds))...)
     if V <: SVector
         V2 = SVector{newdim, T}
     else
@@ -140,7 +140,7 @@ end
 function matstring(d::AbstractStateSpaceSet{D, T}) where {D, T}
     N = length(d)
     if N > 50
-        mat = zeros(eltype(d), 50, D)
+        mat = zeros(eltype(eltype(d)), 50, D)
         for (i, a) in enumerate(flatten((1:25, N-24:N)))
             mat[i, :] .= d[a]
         end

--- a/test/ssset_distance_tests.jl
+++ b/test/ssset_distance_tests.jl
@@ -90,4 +90,11 @@ end
         @test dsds[2][1] == 1
         @test dsds[1][2] == 1
     end
+
+    @testset "empty sets" begin
+        d = StateSpaceSet{2, Float64}()
+        set = Dict{Int, typeof(d)}()
+        dsds = setsofsets_distances(set, set)
+        @test isempty(dsds)
+    end
 end

--- a/test/ssset_tests.jl
+++ b/test/ssset_tests.jl
@@ -38,7 +38,7 @@ s = StateSpaceSet(o)
     tt = fill("tt", 10)
     ss = StateSpaceSet(ff, tt)
     @test dimension(ss) == 2
-    @test eltype(ss) == String
+    @test eltype(eltype(ss)) == String
   end
 end
 


### PR DESCRIPTION
See changelog. This fixes downstream problems in Attractors.jl where during a continuation if all initial conditions diverge in two subsequent steps the continuation errors.