### PR TITLE
Fix for NearestNeighbors v0.4.23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "StateSpaceSets"
 uuid = "40b095a5-5852-4c12-98c7-d43bf788e795"
 authors = ["George Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaDynamics/StateSpaceSets.jl.git"
-version = "2.5.2"
+version = "2.5.3"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/set_distance.jl
+++ b/src/set_distance.jl
@@ -121,7 +121,7 @@ function set_distance_tree(d1, tree::KDTree, comparison = <)
     dist, idx = [ε], [0]
     for p in d1 # iterate over all points of set
         Neighborhood.NearestNeighbors.knn_point!(
-            tree, p, false, dist, idx, Neighborhood.NearestNeighbors.always_false
+            tree, p, false, dist, idx, Returns(false)
         )
         @inbounds comparison(dist[1], ε) && (ε = dist[1])
     end


### PR DESCRIPTION
The most recent version of `NearestNeighbors.jl` (v0.4.23, [#193](https://github.com/KristofferC/NearestNeighbors.jl/pull/193)) removed the definition of the function `always_false` which `StateSpaceSets.jl` references in the `set_distance_tree` function. Replacing this with `Returns(false)` allows all Julia tests to pass again  
